### PR TITLE
Remove newrelic library dependency

### DIFF
--- a/tracing-newrelic.cabal
+++ b/tracing-newrelic.cabal
@@ -24,7 +24,7 @@ library
       src
   default-extensions: NamedFieldPuns NoImplicitPrelude OverloadedStrings Strict
   extra-libraries:
-      pcre, pthread, newrelic
+      pcre, pthread
   build-depends:
       base
     , text


### PR DESCRIPTION
We build this dependency in our `Setup.hs` script. Declaring the
dependency in the cabal file seems to break Nix, which starts looking
for a derivation called `newrelic` and won't be able to find it.