### PR TITLE
Fix for memory corruption bug

### DIFF
--- a/src/FreeAfter.hs
+++ b/src/FreeAfter.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveFunctor #-}
+module FreeAfter (FreeAfter(..), freeAfter) where
+
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Prelude
+
+-- | A type for performing operations and freeing memory that was used during
+-- them once these operations are done.
+newtype FreeAfter b a = FreeAfter { runFreeAfter :: (a -> IO b) -> IO b } deriving (Functor)
+
+freeAfter :: FreeAfter a a -> IO a
+freeAfter task = runFreeAfter task pure
+
+instance Applicative (FreeAfter b) where
+  pure x = FreeAfter $ \run -> run x
+  FreeAfter f <*> FreeAfter x =
+    FreeAfter $ \run -> f (\f' -> x (\x' -> run (f' x') ))
+
+instance Monad (FreeAfter b) where
+  FreeAfter x >>= f = FreeAfter $ \run ->
+    x (\x' ->
+        let
+          (FreeAfter y) = f x'
+        in y run
+      )
+
+instance MonadIO (FreeAfter b) where
+  liftIO io = FreeAfter $ \f -> io >>= f

--- a/src/Tracing/NewRelic.hsc
+++ b/src/Tracing/NewRelic.hsc
@@ -2,6 +2,7 @@
 {-# LANGUAGE NoStrict #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveFunctor #-}
 -- Our default `Strict` policy will cause runtime errors for this module. See:
 -- https://gitlab.haskell.org/ghc/ghc/issues/16810
 
@@ -106,6 +107,7 @@ module Tracing.NewRelic
     )
 where
 
+import Control.Monad.IO.Class (MonadIO(liftIO))
 import Data.Int (Int, Int16, Int32, Int64)
 import Data.Word (Word64)
 import qualified Data.Text as Text
@@ -336,7 +338,7 @@ instance Storable ExternalSegment where
       <*> (peekMaybeTextOff ptr (#offset newrelic_external_segment_params_t, procedure))
       <*> (peekMaybeTextOff ptr (#offset newrelic_external_segment_params_t, library))
 
-  poke ptr (ExternalSegment uri procedure library) = do
+  poke ptr (ExternalSegment uri procedure library) = freeAfter $ do
     pokeTextOff ptr (#offset newrelic_external_segment_params_t, uri) uri
     pokeMaybeTextOff ptr (#offset newrelic_external_segment_params_t, procedure) procedure
     pokeMaybeTextOff ptr (#offset newrelic_external_segment_params_t, library) library
@@ -472,7 +474,7 @@ instance Storable DatastoreSegment where
           Just (#const_str NEWRELIC_DATASTORE_REDIS) -> Redis
           Just text -> OtherDatastoreSegmentProduct text
 
-  poke ptr (DatastoreSegment product' collection operation host portPathOrId databaseName query) = do
+  poke ptr (DatastoreSegment product' collection operation host portPathOrId databaseName query) = freeAfter $ do
     pokeDatastoreSegmentProductOff ptr (#offset newrelic_datastore_segment_params_t, product) product'
     pokeMaybeTextOff ptr (#offset newrelic_datastore_segment_params_t, collection) collection
     pokeMaybeTextOff ptr (#offset newrelic_datastore_segment_params_t, operation) operation
@@ -481,8 +483,8 @@ instance Storable DatastoreSegment where
     pokeMaybeTextOff ptr (#offset newrelic_datastore_segment_params_t, database_name) databaseName
     pokeMaybeTextOff ptr (#offset newrelic_datastore_segment_params_t, query) query
     where
-      pokeDatastoreSegmentProductOff :: Ptr a -> Int -> DatastoreSegmentProduct -> IO ()
-      pokeDatastoreSegmentProductOff ptr' offset datastoreSegmentProduct = do
+      pokeDatastoreSegmentProductOff :: Ptr a -> Int -> DatastoreSegmentProduct -> FreeAfter () ()
+      pokeDatastoreSegmentProductOff ptr' offset datastoreSegmentProduct =
         pokeTextOff ptr' offset $ Text.pack (show datastoreSegmentProduct)
 
 
@@ -526,9 +528,9 @@ init :: DaemonSocket
         -- If this is 0, then a default value will be used.
         -> IO Bool
         -- ^ `True` on success; `False` otherwise.
-init (DaemonSocket daemonSocket) (TimeLimitMs timeLimitMs) =
-  withMaybeTextCString daemonSocket $ \cDaemonSocket ->
-    newrelic_init cDaemonSocket (CInt timeLimitMs)
+init (DaemonSocket daemonSocket) (TimeLimitMs timeLimitMs) = freeAfter $ do
+  cDaemonSocket <- withMaybeTextCString daemonSocket
+  liftIO $ newrelic_init cDaemonSocket (CInt timeLimitMs)
 
 -- |
 -- Configure the C SDK's logging system.
@@ -546,9 +548,9 @@ configureLog :: Text
                 -- The lowest level of log message that will be output.
                 -> IO Bool
                 -- ^ `True` on success; `False` otherwise.
-configureLog filename level =
-  withTextCString filename $ \cFilename ->
-    newrelic_configure_log cFilename (toEnum (fromEnum level))
+configureLog filename level = freeAfter $ do
+  cFilename <- withTextCString filename
+  liftIO $ newrelic_configure_log cFilename (toEnum (fromEnum level))
 
 -- |
 -- Create a populated application configuration.
@@ -569,15 +571,17 @@ createAppConfig :: AppName
                    -> IO AppConfig
                    -- ^ An application configuration populated with "application name" and "license key";
                    -- all other fields are initialized to their defaults.
-createAppConfig (AppName appName) (LicenseKey licenseKey) =
-  withTextCString appName $ \cAppName ->
-    withTextCString licenseKey $ \cLicenseKey -> do
-      configPtr <- newrelic_create_app_config cAppName cLicenseKey
-      if configPtr == nullPtr
-        then throwIO CantCreateNewRelicAppConfig
-        else do
-          foreignConfigPtr <- newForeignPtr configPtr (destroy configPtr newrelic_destroy_app_config)
-          pure $ AppConfig foreignConfigPtr
+createAppConfig (AppName appName) (LicenseKey licenseKey) = freeAfter $ do
+  cAppName <- withTextCString appName
+  cLicenseKey <- withTextCString licenseKey
+  configPtr <- liftIO $ newrelic_create_app_config cAppName cLicenseKey
+  if configPtr == nullPtr
+    then liftIO $ throwIO CantCreateNewRelicAppConfig
+    else do
+      foreignConfigPtr <- liftIO $ newForeignPtr configPtr $ freeAfter $ do
+        ptr <- destroy configPtr
+        liftIO $ newrelic_destroy_app_config ptr
+      pure $ AppConfig foreignConfigPtr
 
 -- |
 -- Specifies whether or not distributed tracing is enabled.
@@ -682,14 +686,16 @@ createApp :: AppConfig
              -- ^
              -- An allocated application, or throws on error; any errors resulting from a
              -- badly-formed configuration are logged.
-createApp (AppConfig foreignAppConfigPtr) (TimeoutMs timeout) =
-  withForeignPtr foreignAppConfigPtr $ \appConfigPtr -> do
-    appPtr <- newrelic_create_app appConfigPtr (CShort timeout)
-    if appPtr == nullPtr
-      then throwIO CantCreateNewRelicApp
-      else do
-        foreignAppPtr <- newForeignPtr appPtr (destroy appPtr newrelic_destroy_app)
-        pure $ App foreignAppPtr
+createApp (AppConfig foreignAppConfigPtr) (TimeoutMs timeout) = freeAfter $ do
+  appConfigPtr <- FreeAfter $ withForeignPtr foreignAppConfigPtr
+  appPtr <- liftIO $ newrelic_create_app appConfigPtr (CShort timeout)
+  if appPtr == nullPtr
+    then liftIO $ throwIO CantCreateNewRelicApp
+    else do
+      foreignAppPtr <- liftIO $ newForeignPtr appPtr $ freeAfter $ do
+        ptr <- destroy appPtr
+        liftIO $ newrelic_destroy_app ptr
+      pure $ App foreignAppPtr
 
 -- |
 -- Start a web based transaction.
@@ -705,13 +711,13 @@ startWebTransaction :: App
                       -- The name for the transaction.
                       -> IO (Maybe Transaction)
                       -- Just a transaction, or `Nothing` if the transaction couldn't be created.
-startWebTransaction (App foreignAppPtr) name =
-  withForeignPtr foreignAppPtr $ \appPtr ->
-    withTextCString name $ \cName -> do
-      transactionPtr <- newrelic_start_web_transaction appPtr cName
-      if transactionPtr == nullPtr
-        then pure Nothing
-        else pure $ Just $ Transaction transactionPtr
+startWebTransaction (App foreignAppPtr) name = freeAfter $ do
+  appPtr <- FreeAfter $ withForeignPtr foreignAppPtr
+  cName <- withTextCString name
+  transactionPtr <- liftIO $ newrelic_start_web_transaction appPtr cName
+  if transactionPtr == nullPtr
+    then pure Nothing
+    else pure $ Just $ Transaction transactionPtr
 
 -- |
 -- Start a non-web based transaction.
@@ -727,13 +733,13 @@ startNonWebTransaction :: App
                           -- The name for the transaction.
                           -> IO (Maybe Transaction)
                           -- Just a transaction, or `Nothing` if the transaction couldn't be created.
-startNonWebTransaction (App foreignAppPtr) name =
-  withForeignPtr foreignAppPtr $ \appPtr ->
-    withTextCString name $ \cName -> do
-      transactionPtr <- newrelic_start_non_web_transaction appPtr cName
-      if transactionPtr == nullPtr
-        then pure Nothing
-        else pure $ Just $ Transaction transactionPtr
+startNonWebTransaction (App foreignAppPtr) name = freeAfter $ do
+  appPtr <- FreeAfter $ withForeignPtr foreignAppPtr
+  cName <- withTextCString name
+  transactionPtr <- liftIO $ newrelic_start_non_web_transaction appPtr cName
+  if transactionPtr == nullPtr
+    then pure Nothing
+    else pure $ Just $ Transaction transactionPtr
 
 -- |
 -- Ignore the current transaction.
@@ -783,8 +789,9 @@ setTransactionTiming (Transaction transactionPtr) (StartTimeUsSinceUnixEpoch sta
 --
 -- Returns `False` if data cannot be sent to newrelic; true otherwise.
 endTransaction :: Transaction -> IO Bool
-endTransaction (Transaction transactionPtr) =
-  allocatePointerWith transactionPtr $ newrelic_end_transaction
+endTransaction (Transaction transactionPtr) = freeAfter $ do
+  transaction <- allocatePointerWith transactionPtr
+  liftIO $ newrelic_end_transaction transaction
 
 -- |
 -- Record the start of a custom segment in a transaction.
@@ -802,11 +809,11 @@ startSegment :: Transaction
                 -- this defaults to "Custom".
                 -> IO (Maybe Segment)
                 -- ^ A valid segment. `Nothing` if the segment couldn't be created.
-startSegment transaction@(Transaction transactionPtr) name category =
-  withMaybeTextCString name $ \cName ->
-    withMaybeTextCString category $ \cCategory -> do
-      segmentPtr <- newrelic_start_segment transactionPtr cName cCategory
-      startSegmentHelper transaction segmentPtr
+startSegment transaction@(Transaction transactionPtr) name category = freeAfter $ do
+  cName <- withMaybeTextCString name
+  cCategory <- withMaybeTextCString category
+  segmentPtr <- liftIO $ newrelic_start_segment transactionPtr cName cCategory
+  liftIO $ startSegmentHelper transaction segmentPtr
 
 -- |
 -- Start recording an external segment within a transaction.
@@ -824,10 +831,10 @@ startExternalSegment :: Transaction
                         -- If an error occurs when creating the external segment,
                         -- `Nothing` is returned, and a log message will be written
                         -- to the SDK log at LOG_ERROR level.
-startExternalSegment transaction@(Transaction transactionPtr) externalSegment =
-  allocatePointerWith externalSegment $ \externalSegmentPtr -> do
-    segmentPtr <- newrelic_start_external_segment transactionPtr externalSegmentPtr
-    startSegmentHelper transaction segmentPtr
+startExternalSegment transaction@(Transaction transactionPtr) externalSegment = freeAfter $ do
+    externalSegmentPtr <- allocatePointerWith externalSegment
+    segmentPtr <- liftIO $ newrelic_start_external_segment transactionPtr externalSegmentPtr
+    liftIO $ startSegmentHelper transaction segmentPtr
 
 -- |
 -- Record the start of a datastore segment in a transaction.
@@ -845,10 +852,10 @@ startDatastoreSegment :: Transaction
                         -- If an error occurs when creating the datastore segment,
                         -- `Nothing` is returned, and a log message will be written
                         -- to the SDK log at LOG_ERROR level.
-startDatastoreSegment transaction@(Transaction transactionPtr) datastoreSegment =
-  allocatePointerWith datastoreSegment $ \datastoreSegmentPtr -> do
-    segmentPtr <- newrelic_start_datastore_segment transactionPtr datastoreSegmentPtr
-    startSegmentHelper transaction segmentPtr
+startDatastoreSegment transaction@(Transaction transactionPtr) datastoreSegment = freeAfter $ do
+  datastoreSegmentPtr <- allocatePointerWith datastoreSegment
+  segmentPtr <- liftIO $ newrelic_start_datastore_segment transactionPtr datastoreSegmentPtr
+  liftIO $ startSegmentHelper transaction segmentPtr
 
 startSegmentHelper :: Transaction -> Ptr Segment -> IO (Maybe Segment)
 startSegmentHelper transaction segmentPtr =
@@ -917,8 +924,9 @@ endSegment :: Segment
               -- ^ `True` if the parameters represented an active segment to record as complete;
                 -- `False` otherwise. If an error occurred, a log message will be written to the
                 -- SDK log at LOG_ERROR level.
-endSegment (Segment (Transaction transactionPtr) segmentPtr) =
-  allocatePointerWith segmentPtr $ newrelic_end_segment transactionPtr
+endSegment (Segment (Transaction transactionPtr) segmentPtr) = freeAfter $ do
+  segment <- allocatePointerWith segmentPtr
+  liftIO $ newrelic_end_segment transactionPtr segment
 
 -- |
 -- Add a custom integer attribute to a transaction.
@@ -928,9 +936,9 @@ addAttributeInt :: Transaction  -- ^ An active transaction
                    -> Text      -- ^ The name of the attribute.
                    -> Int32     -- ^ The integer value of the attribute.
                    -> IO Bool   -- ^ `True` if successful; `False` otherwise.
-addAttributeInt (Transaction transactionPtr) key value =
-  withTextCString key $ \cKey ->
-    newrelic_add_attribute_int transactionPtr cKey (CInt value)
+addAttributeInt (Transaction transactionPtr) key value = freeAfter $ do
+  cKey <- withTextCString key
+  liftIO $ newrelic_add_attribute_int transactionPtr cKey (CInt value)
 
 -- |
 -- Add a custom long attribute to a transaction.
@@ -940,9 +948,9 @@ addAttributeLong :: Transaction  -- ^ An active transaction
                     -> Text      -- ^ The name of the attribute.
                     -> Int64     -- ^ The long value of the attribute.
                     -> IO Bool   -- ^ `True` if successful; `False` otherwise.
-addAttributeLong (Transaction transactionPtr) key value =
-  withTextCString key $ \cKey ->
-    newrelic_add_attribute_long transactionPtr cKey (CLong value)
+addAttributeLong (Transaction transactionPtr) key value = freeAfter $ do
+  cKey <- withTextCString key
+  liftIO $ newrelic_add_attribute_long transactionPtr cKey (CLong value)
 
 -- |
 -- Add a custom double attribute to a transaction.
@@ -952,9 +960,9 @@ addAttributeDouble :: Transaction  -- ^ An active transaction
                       -> Text      -- ^ The name of the attribute.
                       -> Double    -- ^ The double value of the attribute.
                       -> IO Bool   -- ^ `True` if successful; `False` otherwise.
-addAttributeDouble (Transaction transactionPtr) key value =
-  withTextCString key $ \cKey ->
-    newrelic_add_attribute_double transactionPtr cKey (CDouble value)
+addAttributeDouble (Transaction transactionPtr) key value = freeAfter $ do
+  cKey <- withTextCString key
+  liftIO $ newrelic_add_attribute_double transactionPtr cKey (CDouble value)
 
 -- |
 -- Add a custom text attribute to a transaction.
@@ -964,10 +972,10 @@ addAttributeText :: Transaction  -- ^ An active transaction
                     -> Text      -- ^ The name of the attribute.
                     -> Text      -- ^ The text value of the attribute.
                     -> IO Bool   -- ^ `True` if successful; `False` otherwise.
-addAttributeText (Transaction transactionPtr) key value =
-  withTextCString key $ \cKey ->
-    withTextCString value $ \cValue ->
-      newrelic_add_attribute_string transactionPtr cKey cValue
+addAttributeText (Transaction transactionPtr) key value = freeAfter $ do
+  cKey <- withTextCString key
+  cValue <- withTextCString value
+  liftIO $ newrelic_add_attribute_string transactionPtr cKey cValue
 
 -- |
 -- Generate a custom metric.
@@ -978,9 +986,9 @@ recordCustomMetric :: Transaction -- ^ An active transaction
                       -> Text     -- ^ The name/identifier for the metric.
                       -> Double   -- ^ The amount of time the metric will record, in milliseconds.
                       -> IO Bool  -- ^ `True` if successful; `False` otherwise.
-recordCustomMetric (Transaction transactionPtr) metricName milliseconds =
-  withTextCString (Text.append "Custom/" metricName) $ \cMetricName ->
-    newrelic_record_custom_metric transactionPtr cMetricName (CDouble milliseconds)
+recordCustomMetric (Transaction transactionPtr) metricName milliseconds = freeAfter $ do
+  cMetricName <- withTextCString (Text.append "Custom/" metricName)
+  liftIO $ newrelic_record_custom_metric transactionPtr cMetricName (CDouble milliseconds)
 
 -- |
 -- Record an error in a transaction.
@@ -996,10 +1004,10 @@ noticeError :: Transaction -- ^ An active transaction.
                -> Text
                -- ^ A string comprising the error class.
                -> IO ()
-noticeError (Transaction transactionPtr) priority errorMessage errorClass =
-  withTextCString errorMessage $ \cErrorMessage ->
-    withTextCString errorClass $ \cErrorClass ->
-      newrelic_notice_error transactionPtr (CInt priority) cErrorMessage cErrorClass
+noticeError (Transaction transactionPtr) priority errorMessage errorClass = freeAfter $ do
+  cErrorMessage <- withTextCString errorMessage
+  cErrorClass <- withTextCString errorClass
+  liftIO $ newrelic_notice_error transactionPtr (CInt priority) cErrorMessage cErrorClass
 
 -- |
 -- Creates a custom event.
@@ -1014,13 +1022,13 @@ createCustomEvent :: Text
                      -- ^ The type/name of the event
                      -> IO (Maybe CustomEvent)
                      -- ^ A custom event, or `Nothing` if the event couldn't be created.
-createCustomEvent eventType =
-  withTextCString eventType $ \cEventType -> do
-    customEventPtr <- newrelic_create_custom_event cEventType
-    if customEventPtr == nullPtr then
-      pure Nothing
-    else
-      fmap (Just . CustomEvent) $ newrelic_create_custom_event cEventType
+createCustomEvent eventType = freeAfter $ do
+  cEventType <- withTextCString eventType
+  customEventPtr <- liftIO $ newrelic_create_custom_event cEventType
+  if customEventPtr == nullPtr then
+    pure Nothing
+  else
+    liftIO $ fmap (Just . CustomEvent) $ newrelic_create_custom_event cEventType
 
 -- |
 -- Records the custom event.
@@ -1028,8 +1036,9 @@ createCustomEvent eventType =
 -- Given an active transaction, this function adds the custom event to the transaction
 -- and timestamps it, ensuring the event will be sent to New Relic.
 recordCustomEvent :: Transaction -> CustomEvent -> IO ()
-recordCustomEvent (Transaction transactionPtr) (CustomEvent eventPtr) =
-  allocatePointerWith eventPtr $ newrelic_record_custom_event transactionPtr
+recordCustomEvent (Transaction transactionPtr) (CustomEvent eventPtr) = freeAfter $ do
+  event <- allocatePointerWith eventPtr
+  liftIO $ newrelic_record_custom_event transactionPtr event
 
 -- |
 -- Adds an int key/value pair to the custom event's attributes.
@@ -1039,9 +1048,9 @@ customEventAddAttributeInt :: CustomEvent  -- ^ A custom event,
                               -> Text      -- ^ the string key for the key/value pair
                               -> Int32     -- ^ the integer value of the key/value pair
                               -> IO Bool   -- ^ `False` indicates the attribute could not be added
-customEventAddAttributeInt (CustomEvent eventPtr) key value =
-  withTextCString key $ \cKey ->
-    newrelic_custom_event_add_attribute_int eventPtr cKey (CInt value)
+customEventAddAttributeInt (CustomEvent eventPtr) key value = freeAfter $ do
+  cKey <- withTextCString key
+  liftIO $ newrelic_custom_event_add_attribute_int eventPtr cKey (CInt value)
 
 -- |
 -- Adds a long key/value pair to the custom event's attributes.
@@ -1051,9 +1060,9 @@ customEventAddAttributeLong :: CustomEvent  -- ^ A custom event,
                                -> Text      -- ^ the string key for the key/value pair
                                -> Int64     -- ^ the long value of the key/value pair
                                -> IO Bool   -- ^ `False` indicates the attribute could not be added
-customEventAddAttributeLong (CustomEvent eventPtr) key value =
-  withTextCString key $ \cKey ->
-    newrelic_custom_event_add_attribute_long eventPtr cKey (CLong value)
+customEventAddAttributeLong (CustomEvent eventPtr) key value = freeAfter $ do
+  cKey <- withTextCString key
+  liftIO $ newrelic_custom_event_add_attribute_long eventPtr cKey (CLong value)
 
 -- |
 -- Adds a double key/value pair to the custom event's attributes.
@@ -1063,9 +1072,9 @@ customEventAddAttributeDouble :: CustomEvent  -- ^ A custom event,
                                  -> Text      -- ^ the string key for the key/value pair
                                  -> Double    -- ^ the double value of the key/value pair
                                  -> IO Bool   -- ^ `False` indicates the attribute could not be added
-customEventAddAttributeDouble (CustomEvent eventPtr) key value =
-  withTextCString key $ \cKey ->
-    newrelic_custom_event_add_attribute_double eventPtr cKey (CDouble value)
+customEventAddAttributeDouble (CustomEvent eventPtr) key value = freeAfter $ do
+  cKey <- withTextCString key
+  liftIO $ newrelic_custom_event_add_attribute_double eventPtr cKey (CDouble value)
 
 -- |
 -- Adds a text key/value pair to the custom event's attributes.
@@ -1075,10 +1084,10 @@ customEventAddAttributeText :: CustomEvent  -- ^ A custom event,
                                -> Text      -- ^ the string key for the key/value pair
                                -> Text      -- ^ the text value of the key/value pair
                                -> IO Bool   -- ^ `False` indicates the attribute could not be added
-customEventAddAttributeText (CustomEvent eventPtr) key value =
-  withTextCString key $ \cKey ->
-    withTextCString value $ \cValue ->
-      newrelic_custom_event_add_attribute_string eventPtr cKey cValue
+customEventAddAttributeText (CustomEvent eventPtr) key value = freeAfter $ do
+  cKey <- withTextCString key
+  cValue <- withTextCString value
+  liftIO $ newrelic_custom_event_add_attribute_string eventPtr cKey cValue
 
 -- |
 -- Frees the memory for custom events created via the `createCustomEvent` function.
@@ -1086,8 +1095,9 @@ customEventAddAttributeText (CustomEvent eventPtr) key value =
 -- This function is here in case there's an allocated `CustomEvent` that ends up not
 -- being recorded as a custom event, but still needs to be freed.
 discardCustomEvent :: CustomEvent -> IO ()
-discardCustomEvent (CustomEvent eventPtr) =
-  allocatePointerWith eventPtr $ newrelic_discard_custom_event
+discardCustomEvent (CustomEvent eventPtr) = freeAfter $ do
+  event <- allocatePointerWith eventPtr
+  liftIO $ newrelic_discard_custom_event event
 
 -- |
 -- Create a distributed trace payload at the root segment.
@@ -1174,10 +1184,10 @@ acceptDistributedTracePayload :: Transaction
                                  -- ^ Transport type used for communicating the external call.
                                  -> IO Bool
                                  -- ^ `True` on success; `False` otherwise.
-acceptDistributedTracePayload (Transaction transactionPtr) payload transportType =
-  withTextCString payload $ \cPayload ->
-    withCString (show transportType) $ \cTransportType ->
-      newrelic_accept_distributed_trace_payload transactionPtr cPayload cTransportType
+acceptDistributedTracePayload (Transaction transactionPtr) payload transportType = freeAfter $ do
+  cPayload <- withTextCString payload
+  cTransportType <- FreeAfter $ withCString (show transportType)
+  liftIO $ newrelic_accept_distributed_trace_payload transactionPtr cPayload cTransportType
 
 -- |
 -- Accept a distributed trace payload, an HTTP-safe, base64-encoded string.
@@ -1185,10 +1195,10 @@ acceptDistributedTracePayload (Transaction transactionPtr) payload transportType
 -- This function offers the same behaviour as `acceptDistributedTracePayload` but accepts a
 -- base64-encoded string for the payload.
 acceptDistributedTracePayloadHttpSafe :: Transaction -> Text -> TransportType -> IO Bool
-acceptDistributedTracePayloadHttpSafe (Transaction transactionPtr) payload transportType =
-  withTextCString payload $ \cPayload ->
-    withCString (show transportType) $ \cTransportType ->
-      newrelic_accept_distributed_trace_payload_httpsafe transactionPtr cPayload cTransportType
+acceptDistributedTracePayloadHttpSafe (Transaction transactionPtr) payload transportType = freeAfter $ do
+  cPayload <- withTextCString payload
+  cTransportType <- FreeAfter $ withCString (show transportType)
+  liftIO $ newrelic_accept_distributed_trace_payload_httpsafe transactionPtr cPayload cTransportType
 
 -- |
 -- Get the NewRelic C SDK version.
@@ -1204,27 +1214,27 @@ version = do
 -- Helper functions --
 ----------------------
 
-destroy :: Storable a => a -> (Ptr a -> IO b) -> IO b
-destroy ptr f =
-  allocatePointerWith ptr $ f
+destroy :: Storable a => a -> FreeAfter b (Ptr a)
+destroy ptr =
+  allocatePointerWith ptr
 
-withTextCString :: Text -> (CString -> IO a) -> IO a
+withTextCString :: Text -> FreeAfter a CString
 withTextCString text =
-  ByteString.useAsCString (Encoding.encodeUtf8 text)
+  FreeAfter $ ByteString.useAsCString (Encoding.encodeUtf8 text)
 
-withMaybeTextCString :: Maybe Text -> (CString -> IO a) -> IO a
-withMaybeTextCString maybeText callback =
+withMaybeTextCString :: Maybe Text -> FreeAfter a CString
+withMaybeTextCString maybeText =
   case maybeText of
     Just text ->
-      withTextCString text callback
+      withTextCString text
     Nothing ->
-      callback nullPtr
+      pure nullPtr
 
-allocatePointerWith :: Storable a => a -> (Ptr a -> IO b) -> IO b
-allocatePointerWith value callback =
-  alloca $ \ptr -> do
-    poke ptr value
-    callback ptr
+allocatePointerWith :: Storable a => a -> FreeAfter b (Ptr a)
+allocatePointerWith value = do
+  ptr <- FreeAfter alloca
+  liftIO $ poke ptr value
+  pure ptr
 
 cStringToText :: CString -> IO Text
 cStringToText cString =
@@ -1246,16 +1256,40 @@ peekMaybeTextOff ptr offset = do
   value <- peekByteOff ptr offset
   cStringToMaybeText value
 
-pokeTextOff :: Ptr a -> Int -> Text -> IO ()
-pokeTextOff ptr offset text =
-  withTextCString text $ pokeByteOff ptr offset
+pokeTextOff :: Ptr a -> Int -> Text -> FreeAfter () ()
+pokeTextOff ptr offset text = do
+  cstring <- withTextCString text
+  liftIO $ pokeByteOff ptr offset cstring
 
-pokeMaybeTextOff :: Ptr a -> Int -> Maybe Text -> IO ()
+pokeMaybeTextOff :: Ptr a -> Int -> Maybe Text -> FreeAfter () ()
 pokeMaybeTextOff ptr offset maybeText =
   case maybeText of
-    Nothing -> pokeByteOff ptr offset nullPtr
+    Nothing -> liftIO $ pokeByteOff ptr offset nullPtr
     Just text -> pokeTextOff ptr offset text
 
 boolToCInt :: Bool -> CInt
 boolToCInt value =
   CInt (if value then 1 else 0)
+
+-- | A type for performing operations and freeing memory that was used during
+-- them once these operations are done.
+newtype FreeAfter b a = FreeAfter { runFreeAfter :: (a -> IO b) -> IO b } deriving (Functor)
+
+freeAfter :: FreeAfter a a -> IO a
+freeAfter task = runFreeAfter task pure
+
+instance Applicative (FreeAfter b) where
+  pure x = FreeAfter $ \run -> run x
+  FreeAfter f <*> FreeAfter x =
+    FreeAfter $ \run -> f (\f' -> x (\x' -> run (f' x') ))
+
+instance Monad (FreeAfter b) where
+  FreeAfter x >>= f = FreeAfter $ \run ->
+    x (\x' ->
+        let
+          (FreeAfter y) = f x'
+        in y run
+      )
+
+instance MonadIO (FreeAfter b) where
+  liftIO io = FreeAfter $ \f -> io >>= f

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -1,0 +1,81 @@
+module Main (main) where
+
+import Test.Tasty.HUnit
+import Test.Tasty as Tasty
+import Control.Monad.IO.Class (liftIO)
+import FreeAfter(FreeAfter(..), freeAfter)
+import Data.IORef as IORef
+
+main :: IO ()
+main = Tasty.defaultMain tests
+
+tests :: TestTree
+tests = Tasty.testGroup "FreeAfter"
+  [ testCase "Monad instance ensures cleanup operations happen at the end" $ do
+      log' <- IORef.newIORef []
+      freeAfter $ do
+        liftIO $ writeLine log' "A"
+        _ <- withCleanup log' "B"
+        liftIO $ writeLine log' "C"
+        _ <- withCleanup log' "D"
+        liftIO $ writeLine log' "E"
+        -- Log doesn't contain clean-up steps yet.
+        liftIO $ assertLogEquals log'
+          ["A"
+          ,"C"
+          ,"E"
+          ]
+      -- After `freeAfter` log contains the cleanup steps.
+      assertLogEquals log'
+        ["A"
+        ,"C"
+        ,"E"
+        ,"Cleanup after: D"
+        ,"Cleanup after: B"
+        ]
+  , testCase "Applicative instance ensures cleanup operations happen at the end" $ do
+      log' <- IORef.newIORef []
+      freeAfter $ do
+        (\_ _ -> ())
+          <$>
+            (do
+              liftIO $ writeLine log' "A"
+              withCleanup log' "B"
+            )
+          <*>
+            (do
+              liftIO $ writeLine log' "1"
+              withCleanup log' "2"
+            )
+        -- Log doesn't contain clean-up steps yet.
+        liftIO $ assertLogEquals log'
+          ["A"
+          ,"1"
+          ]
+      -- After `freeAfter` log contains the cleanup steps.
+      assertLogEquals log'
+        ["A"
+        ,"1"
+        ,"Cleanup after: 2"
+        ,"Cleanup after: B"
+        ]
+  ]
+
+type Log = IORef.IORef [String]
+
+assertLogEquals :: Log -> [String] -> IO ()
+assertLogEquals log' expectedLines = do
+  lines' <- IORef.readIORef log'
+  assertEqual
+    "log contains expected lines"
+    expectedLines
+    lines'
+
+withCleanup :: Log -> String -> FreeAfter () String
+withCleanup log' str = FreeAfter $ \f -> do
+  f str
+  writeLine log' ("Cleanup after: " ++ str)
+
+writeLine :: Log -> String -> IO ()
+writeLine log' line =
+  IORef.atomicModifyIORef' log' (\lines' -> (lines' ++ [line] ,()))

--- a/tracing-newrelic.cabal
+++ b/tracing-newrelic.cabal
@@ -36,3 +36,18 @@ library
   else
     ghc-options: -j4 -Werror -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns
   default-language: Haskell2010
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs:
+      tests
+      src
+  other-modules:
+      FreeAfter
+  ghc-options: -j4 -Werror -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns
+  build-depends:
+      base
+    , tasty
+    , tasty-hunit
+  default-language: Haskell2010

--- a/tracing-newrelic.cabal
+++ b/tracing-newrelic.cabal
@@ -20,6 +20,8 @@ custom-setup
 library
   exposed-modules:
       Tracing.NewRelic
+  other-modules:
+      FreeAfter
   hs-source-dirs:
       src
   default-extensions: NamedFieldPuns NoImplicitPrelude OverloadedStrings Strict


### PR DESCRIPTION
The strings for different fields in the external and datastore segments was being freed to early. This could result in corrupted data being sent to NewRelic. This commit should address the issue.